### PR TITLE
update irq flags from 0 to IRQF_SHARED when request_irq

### DIFF
--- a/echodev-drv.c
+++ b/echodev-drv.c
@@ -237,7 +237,7 @@ static int echo_probe(struct pci_dev *pdev, const struct pci_device_id *id)
 	irq_nr = pci_irq_vector(pdev, 0);
 	printk("echodev-drv - IRQ Number: %d\n", irq_nr);
 
-	status = devm_request_irq(&pdev->dev, irq_nr, echo_irq_handler, 0,
+	status = devm_request_irq(&pdev->dev, irq_nr, echo_irq_handler, IRQF_SHARED,
 	"echodev-irq", echo);
 	if(status != 0) {
 		printk("echodev-drv - Error requesting interrupt\n");


### PR DESCRIPTION
Hello, I am a beginner of kernel driver. In learning your code example, I encountered an error when requesting an interrupt. The flag applied for interrupt should not be 0. This is not a legal flag (not found in include/linux/interrupt.h),  I can successfully request irq when  set flags to the shared type. So submit this PR modification

```
[  816.559938] genirq: Flags mismatch irq 11. 00000000 (echodev-irq) vs. 00000080 (uhci_hcd:usb1)
[  816.560784] CPU: 0 PID: 2450 Comm: insmod Tainted: G           OE     -------- -  - 4.18.0-553.6.1.el8.x86_64 #1
[  816.560786] Hardware name: QEMU Standard PC (i440FX + PIIX, 1996), BIOS rel-1.16.3-0-ga6ed6b701f0a-prebuilt.qemu.org 04/01/2014
[  816.560787] Call Trace:
[  816.560795]  dump_stack+0x41/0x60
[  816.560800]  __setup_irq.cold.55+0x26/0xcf
[  816.560806]  request_threaded_irq+0x109/0x170
[  816.560809]  devm_request_threaded_irq+0x6d/0xd0
[  816.560811]  ? echo_probe+0x1d0/0x1d0 [echodev]
[  816.560813]  echo_probe+0x192/0x1d0 [echodev]
[  816.560815]  local_pci_probe+0x4e/0x90
[  816.560819]  pci_device_probe+0x109/0x1c0
[  816.560821]  __driver_probe_device+0x141/0x450
[  816.560825]  driver_probe_device+0x1f/0x90
[  816.560826]  ? __device_attach_driver+0x110/0x110
[  816.560828]  __driver_attach+0x7f/0x170
[  816.560829]  ? __device_attach_driver+0x110/0x110
[  816.560831]  bus_for_each_dev+0x7b/0xd0
[  816.560833]  bus_add_driver+0x148/0x200
[  816.560834]  ? 0xffffffffc03c1000
[  816.560835]  driver_register+0x6e/0xc0
[  816.560837]  ? 0xffffffffc03c1000
[  816.560838]  echo_init+0x64/0x1000 [echodev]
[  816.560840]  do_one_initcall+0x46/0x1d0
[  816.560844]  ? do_init_module+0x22/0x230
[  816.560846]  ? kmem_cache_alloc_trace+0x142/0x280
[  816.560849]  do_init_module+0x5a/0x230
[  816.560850]  load_module+0x1582/0x18c0
[  816.560852]  ? __do_sys_finit_module+0xb1/0x110
[  816.560853]  __do_sys_finit_module+0xb1/0x110
[  816.560855]  do_syscall_64+0x5b/0x1b0
[  816.560857]  entry_SYSCALL_64_after_hwframe+0x61/0xc6
```